### PR TITLE
Add support for analytics prediction capture

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,6 +156,13 @@ def main():
                         confidence_level=cfg.inference.confidence,
                         overlap_threshold=cfg.inference.overlap_threshold
                     )
+
+                    if cfg.inference.enable_test_capture:
+                        obj_detect.publish_analytics(
+                            results,
+                            file_path='annotations.txt'
+                        )
+
                     predictions = edgeiq.filter_predictions_by_label(
                         predictions=results.predictions,
                         label_list=cfg.inference.labels

--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ class InferenceConfig:
     overlap_threshold: float
     labels: List[str]
     annotations_file_paths: Optional[List[str]] = None
+    enable_test_capture: bool = False
 
     @classmethod
     def from_dict(cls, cfg: dict):


### PR DESCRIPTION
This change adds test capture to the advanced starter app to enable sharing this ability with customers.